### PR TITLE
Fix Xcode example project builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,11 @@
+*.dylib
 *.elf
 *.pdx
 .DS_Store
 .netrc
 .swiftpm/configuration/registries.json
 .swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
-/.build
+.build
 /Packages
 build
 DerivedData/

--- a/.swiftpm/xcode/xcshareddata/xcschemes/Playdate.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/Playdate.xcscheme
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
    LastUpgradeVersion = "1500"
-   version = "1.8">
+   version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES"

--- a/Examples/Life/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+++ b/Examples/Life/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/Examples/Life/.swiftpm/xcode/xcshareddata/xcschemes/Life.xcscheme
+++ b/Examples/Life/.swiftpm/xcode/xcshareddata/xcschemes/Life.xcscheme
@@ -45,6 +45,13 @@
          Location = "workspace"
          FilePath = ".swiftpm/build-and-run.sh">
       </PathRunnable>
+      <EnvironmentVariables>
+         <EnvironmentVariable
+            key = "TOOLCHAINS"
+            value = "org.swift.59202403071a"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+      </EnvironmentVariables>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/Examples/Life/Package.swift
+++ b/Examples/Life/Package.swift
@@ -36,7 +36,7 @@ let package = Package(
     .target(
       name: "Life",
       dependencies: [
-        .product(name: "CPlaydate", package: "swift-playdate-examples")
+        .product(name: "CPlaydate", package: "playdate-swift-overlay")
       ],
       swiftSettings: swiftSettingsSimulator)
   ])

--- a/Examples/SwiftBreak/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+++ b/Examples/SwiftBreak/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/Examples/SwiftBreak/.swiftpm/xcode/xcshareddata/xcschemes/SwiftBreak.xcscheme
+++ b/Examples/SwiftBreak/.swiftpm/xcode/xcshareddata/xcschemes/SwiftBreak.xcscheme
@@ -45,6 +45,13 @@
          Location = "workspace"
          FilePath = ".swiftpm/build-and-run.sh">
       </PathRunnable>
+      <EnvironmentVariables>
+         <EnvironmentVariable
+            key = "TOOLCHAINS"
+            value = "org.swift.59202403071a"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+      </EnvironmentVariables>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/Examples/SwiftBreak/Package.swift
+++ b/Examples/SwiftBreak/Package.swift
@@ -36,7 +36,7 @@ let package = Package(
     .target(
       name: "SwiftBreak",
       dependencies: [
-        .product(name: "Playdate", package: "swift-playdate-examples")
+        .product(name: "Playdate", package: "playdate-swift-overlay")
       ],
       swiftSettings: swiftSettingsSimulator)
   ])

--- a/Package.swift
+++ b/Package.swift
@@ -35,7 +35,7 @@ let cSettingsSimulator: [CSetting] = [
 ]
 
 let package = Package(
-  name: "swift-playdate-examples",
+  name: "playdate-swift-overlay",
   products: [
     .library(name: "Playdate", targets: ["Playdate"]),
     .library(name: "CPlaydate", targets: ["CPlaydate"]),


### PR DESCRIPTION
Some notes (I think some changes are probably needed before merge):

1. The Life and SwiftBreak examples work great for me now, both when running `TOOLCHAINS="org.swift.59202403071a" make`, or building from Xcode. However, the Template and root package both error still. Specifically for Template:
    1. Trying to `make` gives `make: *** No rule to make target `/Users/paulstraw/dev/playdate-swift-overlay/Sources/CPlaydate/posix_memalign.c', needed by `build//Users/paulstraw/dev/playdate-swift-overlay/Sources/CPlaydate/posix_memalign.o'.  Stop.`
    2. Trying to build in Xcode gives `<unknown>:0: error: Whole module optimization (wmo) must be enabled with embedded Swift.`
2. I had to add `TOOLCHAINS` to the scheme env vars to build within Xcode. This feels like a bit of a smell, but I haven't been able to find a better approach. Some more context in the commit message.