### PR TITLE
LCDColor & adding PlaydateEx module on main package

### DIFF
--- a/Examples/Patterns/.nova/Tasks/Playdate Simulator.json
+++ b/Examples/Patterns/.nova/Tasks/Playdate Simulator.json
@@ -1,0 +1,12 @@
+{
+  "extension" : {
+    "identifier" : "com.panic.Playdate",
+    "name" : "Playdate"
+  },
+  "extensionTemplate" : "simulator",
+  "extensionValues" : {
+    "playdate.build-type" : "make",
+    "playdate.debugRequest" : "launch",
+    "playdate.product-name" : "Patterns"
+  }
+}

--- a/Examples/Patterns/.swiftpm/build-and-run.sh
+++ b/Examples/Patterns/.swiftpm/build-and-run.sh
@@ -1,0 +1,7 @@
+#! /bin/sh
+set -e
+killall 'Playdate Simulator' || true
+cd ..
+PRODUCT=$(sed -n '/^PRODUCT :=/s///p' Makefile)
+make 
+~/Developer/PlaydateSDK/bin/Playdate\ Simulator.app/Contents/MacOS/Playdate\ Simulator $PRODUCT

--- a/Examples/Patterns/.swiftpm/xcode/xcshareddata/xcschemes/Patterns.xcscheme
+++ b/Examples/Patterns/.swiftpm/xcode/xcshareddata/xcschemes/Patterns.xcscheme
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1500"
+   version = "2.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      buildArchitectures = "Automatic">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "Patterns"
+               BuildableName = "Patterns"
+               BlueprintName = "Patterns"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Release"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Release"
+      selectedDebuggerIdentifier = ""
+      selectedLauncherIdentifier = "Xcode.IDEFoundation.Launcher.PosixSpawn"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <PathRunnable
+         runnableDebuggingMode = "0"
+         Location = "workspace"
+         FilePath = ".swiftpm/build-and-run.sh">
+      </PathRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Release">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Examples/Patterns/.vscode/tasks.json
+++ b/Examples/Patterns/.vscode/tasks.json
@@ -1,0 +1,12 @@
+{
+    // See https://go.microsoft.com/fwlink/?LinkId=733558
+    // for the documentation about the tasks.json format
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "build",
+            "type": "shell",
+            "command": "make && $HOME/Developer/PlaydateSDK/bin/Playdate\\ Simulator.app/Contents/MacOS/Playdate\\ Simulator Patterns.pdx",
+        }
+    ]
+}

--- a/Examples/Patterns/Makefile
+++ b/Examples/Patterns/Makefile
@@ -1,0 +1,32 @@
+REPO_ROOT := $(shell git rev-parse --show-toplevel)
+PRODUCT := Patterns.pdx
+SRC += $(REPO_ROOT)/Sources/CPlaydate/playdate.c
+include $(REPO_ROOT)/Examples/swift.mk
+SWIFT_FLAGS_DEVICE += -module-alias PlaydateEx=playdateex_device
+SWIFT_FLAGS_SIMULATOR += -module-alias PlaydateEx=playdateex_simulator
+
+# MARK: - Build PlaydateEx Overlay Swift Module
+build/Modules/playdateex_device.o: $(REPO_ROOT)/Sources/PlaydateEx/*.swift
+	$(SWIFT_EXEC) $(SWIFT_FLAGS) $(SWIFT_FLAGS_DEVICE) -c $^ -emit-module -o $@
+
+build/Modules/playdateex_simulator.o: $(REPO_ROOT)/Sources/PlaydateEx/*.swift
+	$(SWIFT_EXEC) $(SWIFT_FLAGS) $(SWIFT_FLAGS_SIMULATOR) -c $^ -emit-module -o $@
+
+
+# MARK: - Build Playdate Overlay Swift Module
+build/Modules/playdate_device.o: $(REPO_ROOT)/Sources/Playdate/*.swift
+	$(SWIFT_EXEC) $(SWIFT_FLAGS) $(SWIFT_FLAGS_DEVICE) -c $^ -emit-module -o $@
+
+build/Modules/playdate_simulator.o: $(REPO_ROOT)/Sources/Playdate/*.swift
+	$(SWIFT_EXEC) $(SWIFT_FLAGS) $(SWIFT_FLAGS_SIMULATOR) -c $^ -emit-module -o $@
+
+# MARK: - Build Game Swift Object
+build/game_device.o: Sources/*.swift | build/Modules/playdate_device.o build/Modules/playdateex_device.o
+	$(SWIFT_EXEC) $(SWIFT_FLAGS) $(SWIFT_FLAGS_DEVICE) -c $^ -o $@
+$(OBJDIR)/pdex.elf: build/game_device.o
+OBJS += build/game_device.o
+
+build/game_simulator.o: Sources/*.swift | build/Modules/playdate_simulator.o build/Modules/playdateex_simulator.o
+	$(SWIFT_EXEC) $(SWIFT_FLAGS) $(SWIFT_FLAGS_SIMULATOR) -c $^ -o $@
+$(OBJDIR)/pdex.${DYLIB_EXT}: build/game_simulator.o
+SIMCOMPILER += build/game_simulator.o

--- a/Examples/Patterns/Package.swift
+++ b/Examples/Patterns/Package.swift
@@ -23,33 +23,20 @@ let swiftSettingsSimulator: [SwiftSetting] = [
   ]),
 ]
 
-let cSettingsSimulator: [CSetting] = [
-  .unsafeFlags([
-    "-DTARGET_EXTENSION",
-    "-I", "\(gccIncludePrefix)/include",
-    "-I", "\(gccIncludePrefix)/include-fixed",
-    "-I", "\(gccIncludePrefix)/../../../../arm-none-eabi/include",
-    "-I", "\(home)/Developer/PlaydateSDK/C_API",
-  ])
-]
-
 let package = Package(
-  name: "playdate-swift-overlay",
+  name: "Patterns",
   products: [
-    .library(name: "Playdate", targets: ["Playdate"]),
-    .library(name: "CPlaydate", targets: ["CPlaydate"]),
-    .library(name: "PlaydateEx", targets: ["PlaydateEx"]),
+    .library(name: "Patterns", targets: ["Patterns"])
+  ],
+  dependencies: [
+    .package(path: "../..")
   ],
   targets: [
     .target(
-      name: "Playdate",
-      dependencies: ["CPlaydate"],
-      swiftSettings: swiftSettingsSimulator),
-    .target(
-      name: "CPlaydate",
-      cSettings: cSettingsSimulator),
-    .target(
-      name: "PlaydateEx",
-      dependencies: ["Playdate", "CPlaydate"],
-      swiftSettings: swiftSettingsSimulator),
+      name: "Patterns",
+      dependencies: [
+        .product(name: "Playdate", package: "playdate-swift-overlay"),
+        .product(name: "PlaydateEx", package: "playdate-swift-overlay")
+      ],
+      swiftSettings: swiftSettingsSimulator)
   ])

--- a/Examples/Patterns/Source/pdxinfo
+++ b/Examples/Patterns/Source/pdxinfo
@@ -1,0 +1,5 @@
+name=Patterns
+author=Helio Tejedor
+description=Example Playdate pattern colors
+bundleID=org.swift.panic.patterns
+imagePath=

--- a/Examples/Patterns/Sources/Entry.swift
+++ b/Examples/Patterns/Sources/Entry.swift
@@ -1,0 +1,22 @@
+public import Playdate
+
+nonisolated(unsafe) var game = Game()
+
+@_cdecl("update")
+func update(pointer: UnsafeMutableRawPointer?) -> Int32 {
+    game.updateGame()
+    return 1
+}
+
+@_cdecl("eventHandler")
+public func eventHandler(
+    pointer: UnsafeMutableRawPointer!,
+    event: PDSystemEvent,
+    arg: UInt32
+) -> Int32 {
+    initializePlaydateAPI(with: pointer)
+    if event == .initialize {
+        System.setUpdateCallback(update: update, userdata: nil)
+    }
+    return 0
+}

--- a/Examples/Patterns/Sources/Game.swift
+++ b/Examples/Patterns/Sources/Game.swift
@@ -1,0 +1,55 @@
+internal import Playdate
+internal import PlaydateEx
+
+struct Game {
+    var sprites: [Sprite]
+    var invertedSprite: Sprite
+    
+    init() {
+        let pattern1: LCDPattern = (
+            0xF0, 0xF0, 0xF0, 0xF0, 0x0F, 0x0F, 0x0F, 0x0F,
+            0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF
+        )
+        let pattern2: LCDPattern = (
+            0x55, 0xAA, 0x55, 0xAA, 0x55, 0xAA, 0x55, 0xAA,
+            0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF
+        )
+
+        let colorStyles: [ColorStyle] = [
+            .solid(.colorBlack),
+            .solid(.colorWhite),
+            .pattern(pattern1),
+            .pattern(pattern2)
+        ]
+
+        let widthStep = Display.width / Int32(colorStyles.count)
+        var sprites: [Sprite] = []
+        for (index, colorStyle) in colorStyles.enumerated() {
+            let bitmap = Graphics.newBitmap(width: widthStep, height: Display.height, colorStyle: colorStyle)
+            let newSprite = Sprite(bitmap: bitmap)
+            newSprite.moveTo(x: (Float(index) + 0.5) * Float(widthStep), y: Float(Display.height) / 2)
+            newSprite.addSprite()
+            sprites.append(newSprite)
+        }
+        self.sprites = sprites
+
+        let bitmap = Graphics.newBitmap(width: Display.width / 3, height: Display.height / 3, colorStyle: .solid(.colorClear))
+        let newSprite = Sprite(bitmap: bitmap)
+        newSprite.moveTo(x: Float(Display.width) / 2, y: Float(Display.height) / 2)
+        newSprite.addSprite()
+        self.invertedSprite = newSprite
+    }
+    
+    mutating func updateGame() {
+        let onlyMillis = System.currentTimeMilliseconds % 1000
+        let startAngle = Float(onlyMillis) * 360.0 / 1000.0
+        let endAngle = Float(onlyMillis + 500) * 360.0 / 1000.0
+        let x = Int32(invertedSprite.bounds.width / 2)
+        let y = Int32(invertedSprite.bounds.height / 2)
+        invertedSprite.withImage {
+            Graphics.fillRect(x: x - 25, y: y - 25, width: 50, height: 50, colorStyle: .solid(.colorClear))
+            Graphics.fillEllipse(x: x - 25, y: y - 25, width: 50, height: 50, startAngle: startAngle, endAngle: endAngle, colorStyle: .solid(.colorBlack))
+        }
+        Sprite.updateAndDrawSprites()
+    }
+}

--- a/Examples/Patterns/Sources/Sprite+Extensions.swift
+++ b/Examples/Patterns/Sources/Sprite+Extensions.swift
@@ -1,0 +1,26 @@
+internal import Playdate
+
+extension Sprite {
+    init(bitmapPath: StaticString) {
+        let bitmap = Graphics.loadBitmap(path: bitmapPath)
+        self.init(bitmap: bitmap)
+    }
+    
+    init(bitmap: LCDBitmap) {
+        var width: Int32 = 0
+        var height: Int32 = 0
+        Graphics.getBitmapData(
+            bitmap: bitmap.unsafelyUnwrapped,
+            width: &width,
+            height: &height,
+            rowbytes: nil,
+            mask: nil,
+            data: nil)
+        let bounds = PDRect(x: 0, y: 0, width: Float(width), height: Float(height))
+        
+        self.init()
+        self.setImage(image: bitmap)
+        self.bounds = bounds
+        self.collideRect = bounds
+    }
+}

--- a/Sources/Playdate/Graphics.swift
+++ b/Sources/Playdate/Graphics.swift
@@ -1,6 +1,6 @@
 public import CPlaydate
 
-var graphicsAPI: playdate_graphics { playdateAPI.graphics.unsafelyUnwrapped.pointee }
+public var graphicsAPI: playdate_graphics { playdateAPI.graphics.unsafelyUnwrapped.pointee }
 
 /// Access the Playdate graphics system.
 public enum Graphics {}

--- a/Sources/Playdate/Sprite.swift
+++ b/Sources/Playdate/Sprite.swift
@@ -141,7 +141,7 @@ extension Sprite {
   }
 
   /// Returns the LCDBitmap currently assigned to the given sprite.
-  var image: LCDBitmap? {
+  public var image: LCDBitmap? {
     spriteAPI.getImage.unsafelyUnwrapped(self.pointer)
   }
 

--- a/Sources/PlaydateEx/ColorStyle.swift
+++ b/Sources/PlaydateEx/ColorStyle.swift
@@ -1,0 +1,20 @@
+public import CPlaydate
+
+public enum ColorStyle: Sendable {
+    case solid(LCDSolidColor)
+    case pattern(LCDPattern)
+}
+
+extension ColorStyle {
+    internal func withColorStyle<T>(_ block: (LCDColor) -> T) -> T {
+        switch self {
+        case .solid(let value):
+            block(LCDColor(value.rawValue))
+        case .pattern(let pattern):
+            withUnsafeBytes(of: pattern) {
+                let address = Int(bitPattern: $0.baseAddress.unsafelyUnwrapped)
+                return block(LCDColor(address))
+            }
+        }
+    }
+}

--- a/Sources/PlaydateEx/Graphics+Extensions.swift
+++ b/Sources/PlaydateEx/Graphics+Extensions.swift
@@ -1,0 +1,74 @@
+public import Playdate
+
+extension Graphics {
+    
+    /// Clears bitmap, filling with the given color style.
+    public static func clearBitmap(bitmap: OpaquePointer, colorStyle: ColorStyle) {
+        colorStyle.withColorStyle {
+            graphicsAPI.clearBitmap.unsafelyUnwrapped(bitmap, $0)
+        }
+    }
+    
+    
+    /// Allocates and returns a new width by height LCDBitmap filled with color style.
+    public static func newBitmap(width: Int32, height: Int32, colorStyle: ColorStyle) -> OpaquePointer? {
+        colorStyle.withColorStyle {
+            graphicsAPI.newBitmap.unsafelyUnwrapped(width, height, $0)
+        }
+    }
+    
+    
+    /// Draws an ellipse inside the rectangle {x, y, width, height} of width lineWidth (inset from the rectangle bounds). If `startAngle != _endAngle`, this draws an arc between the given angles. Angles are given in degrees, clockwise from due north.
+    public static func drawEllipse(x: Int32, y: Int32, width: Int32, height: Int32, lineWidth: Int32, startAngle: Float, endAngle: Float, colorStyle: ColorStyle) {
+        colorStyle.withColorStyle {
+            graphicsAPI.drawEllipse.unsafelyUnwrapped(x, y, width, height, lineWidth, startAngle, endAngle, $0)
+        }
+    }
+    
+    /// Fills an ellipse inside the rectangle {x, y, width, height}. If `startAngle != _endAngle`, this draws a wedge/Pacman between the given angles. Angles are given in degrees, clockwise from due north.
+    public static func fillEllipse(x: Int32, y: Int32, width: Int32, height: Int32, startAngle: Float, endAngle: Float, colorStyle: ColorStyle) {
+        colorStyle.withColorStyle {
+            graphicsAPI.fillEllipse.unsafelyUnwrapped(x, y, width, height, startAngle, endAngle, $0)
+        }
+    }
+    
+    
+    /// Draws a line from x1, y1 to x2, y2 with a stroke width of width.
+    public static func drawLine(x1: Int32, y1: Int32, x2: Int32, y2: Int32, width: Int32, colorStyle: ColorStyle) {
+        colorStyle.withColorStyle {
+            graphicsAPI.drawLine.unsafelyUnwrapped(x1, y1, x2, y2, width, $0)
+        }
+    }
+    
+    
+    /// Draws a width by height rect at x, y.
+    public static func drawRect(x: Int32, y: Int32, width: Int32, height: Int32, colorStyle: ColorStyle) {
+        colorStyle.withColorStyle {
+            graphicsAPI.drawRect.unsafelyUnwrapped(x, y, width, height, $0)
+        }
+    }
+    
+    
+    /// Draws a filled width by height rect at x, y.
+    public static func fillRect(x: Int32, y: Int32, width: Int32, height: Int32, colorStyle: ColorStyle) {
+        colorStyle.withColorStyle {
+            graphicsAPI.fillRect.unsafelyUnwrapped(x, y, width, height, $0)
+        }
+    }
+    
+    
+    /// Draws a filled triangle with points at x1, y1, x2, y2, and x3, y3.
+    public static func fillTriangle(x1: Int32, y1: Int32, x2: Int32, y2: Int32, x3: Int32, y3: Int32, colorStyle: ColorStyle) {
+        colorStyle.withColorStyle {
+            graphicsAPI.fillTriangle.unsafelyUnwrapped(x1, y1, x2, y2, x3, y3, $0)
+        }
+    }
+    
+    
+    /// Fills the polygon with vertices at the given coordinates using the given color and fill, or winding, rule.
+    public static func fillPolygon(nPoints: Int32, points: UnsafeMutablePointer<Int32>?, colorStyle: ColorStyle, fillRule: LCDPolygonFillRule) {
+        colorStyle.withColorStyle {
+            graphicsAPI.fillPolygon.unsafelyUnwrapped(nPoints, points, $0, fillRule)
+        }
+    }
+}

--- a/Sources/PlaydateEx/Sprite+Extensions.swift
+++ b/Sources/PlaydateEx/Sprite+Extensions.swift
@@ -1,0 +1,9 @@
+public import Playdate
+
+extension Sprite {
+    public func withImage(_ block: () -> Void) {
+        Graphics.pushContext(target: image.unsafelyUnwrapped)
+        block()
+        Graphics.popContext()
+    }
+}


### PR DESCRIPTION
I'm proposing the enum ColorStyle to use LCDSolidColor or LCDPattern in the Graphics methods. For example:

```
let bitmap = Graphics.newBitmap(width: 100, height: 100, colorStyle: .solid(.colorBlack))
let newSprite = Sprite(bitmap: bitmap)
```

Also, using patterns:

```
let squares: LCDPattern = (
    0xF0, 0xF0, 0xF0, 0xF0, 0x0F, 0x0F, 0x0F, 0x0F,
    0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF
)
let bitmap = Graphics.newBitmap(width: 100, height: 100, colorStyle: .pattern(squares))
let newSprite = Sprite(bitmap: bitmap)
```

It also works on Graphics methods, like:

```
mySprite.withImage {
    Graphics.fillRect(x: x - 25, y: y - 25, width: 50, height: 50, colorStyle: .solid(.colorClear))
    Graphics.fillEllipse(
         x: x - 25, y: y - 25, 
         width: 50, height: 50, 
         startAngle: startAngle, endAngle: endAngle, 
         colorStyle: .solid(.colorBlack))
}
```

Trying to minimize the impact of newer changes that Playdate module could bring to this package, I implemented a new module called PlaydateEx where I propose to add the extensions to the original module.

If you want to use the PlaydateEx module, add these lines to the Makefile file right after the **include** (line 4):

```
SWIFT_FLAGS_DEVICE += -module-alias PlaydateEx=playdateex_device
SWIFT_FLAGS_SIMULATOR += -module-alias PlaydateEx=playdateex_simulator

# MARK: - Build PlaydateEx Overlay Swift Module
build/Modules/playdateex_device.o: $(REPO_ROOT)/Sources/PlaydateEx/*.swift
	$(SWIFT_EXEC) $(SWIFT_FLAGS) $(SWIFT_FLAGS_DEVICE) -c $^ -emit-module -o $@

build/Modules/playdateex_simulator.o: $(REPO_ROOT)/Sources/PlaydateEx/*.swift
	$(SWIFT_EXEC) $(SWIFT_FLAGS) $(SWIFT_FLAGS_SIMULATOR) -c $^ -emit-module -o $@
```

And modify these lines:

    build/game_device.o: Sources/*.swift | build/Modules/playdate_device.o

By:

    build/game_device.o: Sources/*.swift | build/Modules/playdate_device.o build/Modules/playdateex_device.o

And:

    build/game_simulator.o: Sources/*.swift | build/Modules/playdate_simulator.o build/Modules/playdateex_simulator.o

By:

    build/game_simulator.o: Sources/*.swift | build/Modules/playdate_simulator.o

